### PR TITLE
Add uniapp login example

### DIFF
--- a/uniapp-hmj/App.vue
+++ b/uniapp-hmj/App.vue
@@ -1,0 +1,15 @@
+<template>
+  <view>
+    <slot />
+  </view>
+</template>
+
+<script>
+export default {
+  name: 'App'
+}
+</script>
+
+<style>
+/* Global styles */
+</style>

--- a/uniapp-hmj/README.md
+++ b/uniapp-hmj/README.md
@@ -1,0 +1,15 @@
+# 和睦家书 UniApp 项目
+
+此目录为和睦家书小程序的初始代码，采用 uni-app 框架，默认包含三
+个页面：
+
+- `pages/index/index` 首页
+- `pages/todo/index` 代办
+- `pages/mine/index` 我的
+- `pages/login/index` 登录示例
+
+在 `pages.json` 中已经配置好页面路由，可根据需要继续扩展。
+
+登录示例会向 `http://localhost:8080/login` 发送 `POST` 请求，后端需返
+回一个 `token` 字段。收到 token 后会存入本地缓存，可用于后续调
+用需要身份验证的接口。

--- a/uniapp-hmj/main.js
+++ b/uniapp-hmj/main.js
@@ -1,0 +1,10 @@
+import Vue from 'vue'
+import App from './App'
+
+Vue.config.productionTip = false
+App.mpType = 'app'
+
+const app = new Vue({
+  ...App
+})
+app.$mount()

--- a/uniapp-hmj/pages.json
+++ b/uniapp-hmj/pages.json
@@ -1,0 +1,28 @@
+{
+  "pages": [
+    {
+      "path": "pages/index/index",
+      "style": {
+        "navigationBarTitleText": "首页"
+      }
+    },
+    {
+      "path": "pages/todo/index",
+      "style": {
+        "navigationBarTitleText": "代办"
+      }
+    },
+    {
+      "path": "pages/mine/index",
+      "style": {
+        "navigationBarTitleText": "我的"
+      }
+    },
+    {
+      "path": "pages/login/index",
+      "style": {
+        "navigationBarTitleText": "登录"
+      }
+    }
+  ]
+}

--- a/uniapp-hmj/pages/index/index.vue
+++ b/uniapp-hmj/pages/index/index.vue
@@ -1,0 +1,17 @@
+<template>
+  <view class="container">
+    <text>首页</text>
+  </view>
+</template>
+
+<script>
+export default {
+  name: 'HomePage'
+}
+</script>
+
+<style>
+.container {
+  padding: 20rpx;
+}
+</style>

--- a/uniapp-hmj/pages/login/index.vue
+++ b/uniapp-hmj/pages/login/index.vue
@@ -1,0 +1,47 @@
+<template>
+  <view class="container">
+    <input v-model="username" placeholder="用户名" />
+    <input v-model="password" type="password" placeholder="密码" />
+    <button @click="doLogin">登录</button>
+    <text v-if="token">Token: {{ token }}</text>
+  </view>
+</template>
+
+<script>
+import { login } from '../../utils/api.js';
+import { setToken, getToken } from '../../utils/auth.js';
+
+export default {
+  name: 'LoginPage',
+  data() {
+    return {
+      username: '',
+      password: '',
+      token: getToken()
+    };
+  },
+  methods: {
+    async doLogin() {
+      try {
+        const res = await login(this.username, this.password);
+        const t = res.data.token;
+        if (t) {
+          setToken(t);
+          this.token = t;
+        }
+      } catch (e) {
+        console.log('login error', e);
+      }
+    }
+  }
+};
+</script>
+
+<style>
+.container {
+  padding: 20rpx;
+  display: flex;
+  flex-direction: column;
+  gap: 10rpx;
+}
+</style>

--- a/uniapp-hmj/pages/mine/index.vue
+++ b/uniapp-hmj/pages/mine/index.vue
@@ -1,0 +1,31 @@
+<template>
+  <view class="container">
+    <text>我的</text>
+    <button @click="goLogin">去登录</button>
+    <text v-if="token">已登录，token: {{ token }}</text>
+  </view>
+</template>
+
+<script>
+import { getToken } from '../../utils/auth.js';
+
+export default {
+  name: 'MinePage',
+  data() {
+    return {
+      token: getToken()
+    };
+  },
+  methods: {
+    goLogin() {
+      uni.navigateTo({ url: '/pages/login/index' });
+    }
+  }
+}
+</script>
+
+<style>
+.container {
+  padding: 20rpx;
+}
+</style>

--- a/uniapp-hmj/pages/todo/index.vue
+++ b/uniapp-hmj/pages/todo/index.vue
@@ -1,0 +1,17 @@
+<template>
+  <view class="container">
+    <text>代办</text>
+  </view>
+</template>
+
+<script>
+export default {
+  name: 'TodoPage'
+}
+</script>
+
+<style>
+.container {
+  padding: 20rpx;
+}
+</style>

--- a/uniapp-hmj/utils/api.js
+++ b/uniapp-hmj/utils/api.js
@@ -1,0 +1,20 @@
+const BASE_URL = 'http://localhost:8080';
+
+export function login(username, password) {
+  return new Promise((resolve, reject) => {
+    uni.request({
+      url: BASE_URL + '/login',
+      method: 'POST',
+      data: {
+        username,
+        password
+      },
+      success(res) {
+        resolve(res);
+      },
+      fail(err) {
+        reject(err);
+      }
+    });
+  });
+}

--- a/uniapp-hmj/utils/auth.js
+++ b/uniapp-hmj/utils/auth.js
@@ -1,0 +1,13 @@
+const TOKEN_KEY = 'token';
+
+export function setToken(token) {
+  uni.setStorageSync(TOKEN_KEY, token);
+}
+
+export function getToken() {
+  return uni.getStorageSync(TOKEN_KEY);
+}
+
+export function clearToken() {
+  uni.removeStorageSync(TOKEN_KEY);
+}


### PR DESCRIPTION
## Summary
- expand uniapp demo with a login example
- include login page and basic API helpers
- show token information under the Mine page

## Testing
- `node -v`
- `npm -v`


------
https://chatgpt.com/codex/tasks/task_e_6848f633e1b0832db8cb4e350f6deeae